### PR TITLE
Rework timestamp style selection highlight to be an underline

### DIFF
--- a/RMSKIN/Skins/uhe/Time/Digital/timestampgen.inc
+++ b/RMSKIN/Skins/uhe/Time/Digital/timestampgen.inc
@@ -333,7 +333,7 @@ LeftMouseUpAction=#PlayButtonClick#[!SetVariable CurrentStyle R][!UpdateMeasure 
 
 [meterStyleSelectedHighlight]
 Meter=Shape
-Shape=Rectangle 0,0,(#Width# / 7),[meterRelativeTimeButton:H], #CornerRadius# | Extend Highlight | StrokeWidth 0
+Shape=Rectangle (#Width# / 28),(2 * [meterRelativeTimeButton:H] / 3),(#Width# / 14), 4, 2 | Extend Highlight | StrokeWidth 0
 ;add placeholder option to hide errors
 Highlight=Fill Color #LightHighlight#,#NoGradientTransparency#
 DynamicVariables=1


### PR DESCRIPTION
- Closes https://github.com/uhe-org/uhe/issues/13

| Before | After |
| --- | --- |
| ![Rainmeter_sZj2K473oF](https://github.com/user-attachments/assets/f703eef3-374f-4969-aea9-7217b2830ece) | ![Rainmeter_CJj3Gts7Ec](https://github.com/user-attachments/assets/77911c0d-2125-4268-9c33-272496769c60) |

May use the entire button area as a hover highlight instead.